### PR TITLE
Iiris release version fix for new Zabbix versioning format.

### DIFF
--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -61,7 +61,7 @@ sed -i 's/^%postun agent$/%postun agent-iiris/' $RPMBUILD/SPECS/zabbix.spec
 sed -i 's/^%files agent$/%files agent-iiris/' $RPMBUILD/SPECS/zabbix.spec
 
 # Change release/build number (3.2.3-X where X is build number)
-sed -i 's/^\(Release:\s\+\)[0-9]\+%/\1'${IIRIS_RELEASE_VERSION}'%/' $RPMBUILD/SPECS/zabbix.spec
+sed -i 's/^\(Release:\s\+%{[.:?a-z0-9]\+}\)[0-9]\+%/\1'${IIRIS_RELEASE_VERSION}'%/' $RPMBUILD/SPECS/zabbix.spec
 
 # jq as dependency because it's required by docker monitoring script and
 # usually by other monitoring scripts too


### PR DESCRIPTION
Zabbix versioning in zabbix.spec has changed:

**zabbix-4.0.10-1.el7.src.rpm:**
Release:	%{?alphatag:0.}1%{?alphatag}%{?dist}

**zabbix-3.4.10-1.el7.src/zabbix.spec:**
Release:	%{?alphatag:0.}1%{?alphatag}%{?dist}

**zabbix-3.2.3-1.el7.src/zabbix.spec:**
Release: 	1%{?alphatag:.%{alphatag}}%{?dist}

**zabbix-3.4.4-2.el7.src/zabbix.spec:**
Release: 	2%{?alphatag:.%{alphatag}}%{?dist}

This will fix setting the iiris-release-version variable.